### PR TITLE
Add unit tests and multi-target for maximum compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/Base16K/Base16K.csproj
+++ b/Base16K/Base16K.csproj
@@ -1,7 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-  </PropertyGroup>
-
-</Project>

--- a/Base16k.Test/Base16k.Test.csproj
+++ b/Base16k.Test/Base16k.Test.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyName>Knapcode.Base16k.Test</AssemblyName>
+    <RootNamespace>Knapcode.Base16k</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Base16k\Base16k.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Base16k.Test/Base16kTest.cs
+++ b/Base16k.Test/Base16kTest.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace JDanielSmith
+{
+    public class ConvertTest
+    {
+        [Theory]
+        [MemberData(nameof(TripsBytesData))]
+        public void RoundTripsBytes(int length, int seed)
+        {
+            // Arrange
+            var expected = new byte[length];
+            var random = new Random(seed);
+            random.NextBytes(expected);
+
+            // Act
+            var encoded = Convert.ToBase16KString(expected);
+            var actual = Convert.FromBase16KString(encoded);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        public static IEnumerable<object[]> TripsBytesData => Enumerable
+            .Range(0, 17)
+            .Select(i => (int)Math.Pow(2, i))
+            .SelectMany(l =>
+            {
+                var random = new Random(l);
+                return Enumerable
+                    .Range(0, 2)
+                    .Select(i => new object[] { l, random.Next() });
+            });
+
+        public class TheToBase16KStringMethod
+        {
+            [Fact]
+            public void ConvertsKnownInput()
+            {
+                var input = System.Convert.FromBase64String(
+                    "q3PbbFnRWhU9XMTfcnXqZdLqJP1WzEDUW7m7cDX6F5EcGoo1zcvNWa2nxSXVw2+BMRWjJeEnJd8zBhCfFerfQkQyw1jqtJgHHcpQrgYa/5hKOT8gV/Kw9PSqAsa6LUPDx4Lhog==");
+
+                var actual = Convert.ToBase16KString(input);
+
+                Assert.Equal(
+                    "100竜趶腧慚問旌捽艵誙洮碓赖茐嵅绦議嵾煹呰檊嵳沼蕦綧腉浜嶾儱啨艞咜痟峁焉豗竟悑匬嵣窴瘁臜祂縆嚿覄磤輠旼笏插稂膮狔式垂表瀀",
+                    actual);
+            }
+
+            [Fact]
+            public void ConvertsEmptyBytes()
+            {
+                Assert.Equal("0", Convert.ToBase16KString(new byte[0]));
+            }
+
+            [Fact]
+            public void RejectNullInput()
+            {
+                var ex = Assert.Throws<ArgumentNullException>(() => Convert.ToBase16KString(null));
+                Assert.Equal("inArray", ex.ParamName);
+            }
+        }
+
+        public class TheFromBase16KStringMethod
+        {
+            [Fact]
+            public void ConvertsKnownInput()
+            {
+                var input = "100竜趶腧慚問旌捽艵誙洮碓赖茐嵅绦議嵾煹呰檊嵳沼蕦綧腉浜嶾儱啨艞咜痟峁焉豗竟悑匬嵣窴瘁臜祂縆嚿覄磤輠旼笏插稂膮狔式垂表瀀";
+                var expected = System.Convert.FromBase64String(
+                    "q3PbbFnRWhU9XMTfcnXqZdLqJP1WzEDUW7m7cDX6F5EcGoo1zcvNWa2nxSXVw2+BMRWjJeEnJd8zBhCfFerfQkQyw1jqtJgHHcpQrgYa/5hKOT8gV/Kw9PSqAsa6LUPDx4Lhog==");
+
+                var actual = Convert.FromBase16KString(input);
+
+                Assert.Equal(expected, actual);
+            }
+
+            [Fact]
+            public void ConvertsEmptyBytes()
+            {
+                Assert.Equal(Array.Empty<byte>(), Convert.FromBase16KString("0"));
+            }
+
+            [Fact]
+            public void RejectTooShortInput()
+            {
+                var ex = Assert.Throws<FormatException>(() => Convert.FromBase16KString("100竜"));
+                Assert.Equal("Too few Han characters representing binary data.", ex.Message);
+            }
+
+            [Fact]
+            public void RejectsInputNotStartingWithLength()
+            {
+                var ex = Assert.Throws<FormatException>(() => Convert.FromBase16KString("A竜趶腧慚"));
+                Assert.Equal("Unable to find a length value.", ex.Message);
+            }
+
+            [Fact]
+            public void RejectUnparsableLength()
+            {
+                var ex = Assert.Throws<FormatException>(() => Convert.FromBase16KString("9999999999999999999999竜趶腧慚"));
+                Assert.Equal("Unable to parse the length string.", ex.Message);
+            }
+
+            [Fact]
+            public void RejectNullInput()
+            {
+                var ex = Assert.Throws<ArgumentNullException>(() => Convert.FromBase16KString(null));
+                Assert.Equal("input", ex.ParamName);
+            }
+        }
+    }
+}

--- a/Base16k.sln
+++ b/Base16k.sln
@@ -3,7 +3,14 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28729.10
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Base16K", "Base16K\Base16K.csproj", "{3845C7D8-0719-42C2-B91D-05B643398F6A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Base16k", "Base16k\Base16k.csproj", "{3845C7D8-0719-42C2-B91D-05B643398F6A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Base16k.Test", "Base16k.Test\Base16k.Test.csproj", "{7F92754E-5D47-4DC6-A8A5-44DFBBFF7075}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E18DABAE-F200-427E-B6E4-418CCEFA7A52}"
+	ProjectSection(SolutionItems) = preProject
+		LICENSE = LICENSE
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +22,10 @@ Global
 		{3845C7D8-0719-42C2-B91D-05B643398F6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3845C7D8-0719-42C2-B91D-05B643398F6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3845C7D8-0719-42C2-B91D-05B643398F6A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F92754E-5D47-4DC6-A8A5-44DFBBFF7075}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F92754E-5D47-4DC6-A8A5-44DFBBFF7075}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F92754E-5D47-4DC6-A8A5-44DFBBFF7075}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F92754E-5D47-4DC6-A8A5-44DFBBFF7075}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Base16k/Base16k.cs
+++ b/Base16k/Base16k.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Text.RegularExpressions;
-
 
 //
 // Base16k.cpp : Variant of base64 used to efficiently encode  binary into Unicode UTF16 strings. Based on work by
@@ -14,6 +12,8 @@ using System.Text.RegularExpressions;
 // C# port of http://qualapps.blogspot.com/2011/11/base64-for-unicode-utf16.html
 // This code is hereby placed in the Public Domain.
 // J. Daniel Smith, February 23, 2015
+//
+// NuGet package details added by Joel Verhagen on January 30, 2021.
 //
 // More details at http://stackoverflow.com/questions/646974/is-there-a-standard-technique-for-packing-binary-data-into-a-utf-16-string
 //
@@ -27,7 +27,7 @@ public static partial class Convert
 	/// </summary>
 	public static string ToBase16KString(byte[] inArray)
 	{
-		if (inArray == null) throw new ArgumentNullException("inArray");
+		if (inArray == null) throw new ArgumentNullException(nameof(inArray));
 
 		int len = inArray.Length;
 
@@ -100,13 +100,23 @@ public static partial class Convert
 		string s = input;
 
 		// read the length
-		var r = new Regex(@"^\d+", RegexOptions.None, matchTimeout: TimeSpan.FromMilliseconds(100));
-		Match m = r.Match(s);
-		if (!m.Success)
-			throw new FormatException("Unable to find a length value.");
+		var lengthEnd = -1;
+		for (var l = 0; l < s.Length; l++)
+		{
+			if (s[l] >= '0' && s[l] <= '9')
+			{
+				lengthEnd = l;
+			}
+			else
+			{
+				break;
+			}
+		}
+
+		if (lengthEnd < 0) throw new FormatException("Unable to find a length value.");
 
 		int length;
-		if (!Int32.TryParse(m.Value, out length))
+		if (!Int32.TryParse(s.Substring(0, lengthEnd + 1), out length))
 			throw new FormatException("Unable to parse the length string.");
 
 		var buf = new List<byte>(length);

--- a/Base16k/Base16k.csproj
+++ b/Base16k/Base16k.csproj
@@ -19,6 +19,8 @@ C# port of http://qualapps.blogspot.com/2011/11/base64-for-unicode-utf16.html
 This code is hereby placed in the Public Domain.
 J. Daniel Smith, February 23, 2015
 
+NuGet package details added by Joel Verhagen on January 30, 2021.
+
 More details at http://stackoverflow.com/questions/646974/is-there-a-standard-technique-for-packing-binary-data-into-a-utf-16-string
     </Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Base16k/Base16k.csproj
+++ b/Base16k/Base16k.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks Condition="'$(CoreOnly)' != 'true'">netstandard1.0;net40</TargetFrameworks>
+    <TargetFrameworks Condition="'$(CoreOnly)' == 'true'">netstandard1.0</TargetFrameworks>
+    <RootNamespace>JDanielSmith</RootNamespace>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+    <Version>1.0.0</Version>
+    <Authors>Markus Scherer, Jim Beveridge, J. Daniel Smith, Joel Verhagen</Authors>
+    <Description>
+Base16k.cpp : Variant of base64 used to efficiently encode  binary into Unicode UTF16 strings. Based on work by
+Markus Scherer at https://sites.google.com/site/markusicu/unicode/base16k
+
+This code is hereby placed in the Public Domain.
+Jim Beveridge, November 29, 2011.
+
+C# port of http://qualapps.blogspot.com/2011/11/base64-for-unicode-utf16.html
+This code is hereby placed in the Public Domain.
+J. Daniel Smith, February 23, 2015
+
+More details at http://stackoverflow.com/questions/646974/is-there-a-standard-technique-for-packing-binary-data-into-a-utf-16-string
+    </Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/JDanielSmith/Base16k</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <CoreOnly Condition="'$(CoreOnly)' == '' and !$([MSBuild]::IsOSPlatform('Windows'))">true</CoreOnly>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Hey J. Daniel Smith,

I found this library the StackOverflow question referenced in your source and was happy to see a C# implementation.

What do you think about making it a NuGet package? This could ease re-use. A description of my changes is enumerated below but I added some start metadata for this purpose.

I made a couple of tweaks to improve cross-platform usage.

Question for you: is this code public domain, or is it MIT? I see the LICENSE file at the root of the repo says MIT but some comments and text say public domain, so I'm not sure. Right now, I have the .nupkg license info set to MIT to be on the safe side.

I'm happy to publish it to NuGet.org and add you as an owner, or you can do it if you'd like sole ownership -- whatever works best for you.

Also, I'm happy to adjust this PR to meet your requirements. My primary goal is having it on NuGet but I figured I'd polish a couple of other things while I was in there.

## Changes:

- Add unit tests
- Change from regex to simple parsing to allow net40 compat
- Mutli-target to netstandard1.0 and net40
- Add NuGet package metadata
- Add GitHub Actions definition for build and test
- Rename directories and files to be consistently "Base16k"